### PR TITLE
fix: escape iCalendar fields to prevent stored XSS (#22)

### DIFF
--- a/lib/js/display.js
+++ b/lib/js/display.js
@@ -37,7 +37,10 @@ class Display {
         
         if (this.array_response['found_advance']) {
             if (!this.array_response['is_sequences_equal']) {
-                $event_found_on_server.html(rcmail.gettext('modified_event', 'roundcube_caldav') + this.array_response['found_on_calendar']['display_name']);
+                $event_found_on_server.empty().append(
+                    document.createTextNode(rcmail.gettext('modified_event', 'roundcube_caldav')),
+                    document.createTextNode(this.array_response['found_on_calendar']['display_name'])
+                );
             } else {
                 $event_found_on_server.hide();
             }
@@ -179,13 +182,13 @@ class Display {
         if (this.array_response['description'] && display_description) {
             $div_location_description.show();
             $description.show();
-            $description.append(this.array_response['description']);
+            $description.text(this.array_response['description']);
         }
         
         if (this.array_response['location'] && display_location) {
             $div_location_description.show();
             $location.show();
-            $location.append(this.array_response['location']);
+            $location.text(this.array_response['location']);
         }
     }
 
@@ -205,13 +208,13 @@ class Display {
         if (this.array_response['new_location']) {
             $div_location_description.show();
             $new_location.show();
-            $new_location.append(this.array_response['new_location'])
+            $new_location.text(this.array_response['new_location']);
         }
         
         if (this.array_response['new_description']) {
             $div_location_description.show();
             $new_description.show();
-            $new_description.append(this.array_response['new_description'])
+            $new_description.text(this.array_response['new_description']);
         }
     }
 
@@ -224,8 +227,8 @@ class Display {
             let $comment = this.event_template_html.find('.comment');
             $comment.show();
 
-            $comment.append('<div><b>' + rcmail.gettext("comment", "roundcube_caldav") + '</b></div>');
-            $comment.append('<div>' + this.array_response['comment'] + '</div>');
+            $comment.append($('<div>').append($('<b>').text(rcmail.gettext("comment", "roundcube_caldav"))));
+            $comment.append($('<div>').text(this.array_response['comment']));
         }
     }
 
@@ -237,7 +240,6 @@ class Display {
         if (this.array_response['attendees'] !== undefined) {
             for (let attendee of this.array_response['attendees']) {
 
-                let link = '';
                 let display = attendee['name'] ? attendee['name'] : attendee["email"];
                 let status;
                 // let tentative_logo = '<svg aria-hidden="true" focusable="false" style="height: 1.5em; width: 1.5em"  data-prefix="fas" data-icon="ban" class="logo svg-inline--fa fa-ban" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M256 0C114.6 0 0 114.6 0 256s114.6 256 256 256s256-114.6 256-256S397.4 0 256 0zM64 256c0-41.4 13.3-79.68 35.68-111.1l267.4 267.4C335.7 434.7 297.4 448 256 448C150.1 448 64 361.9 64 256zM412.3 367.1L144.9 99.68C176.3 77.3 214.6 64 256 64c105.9 0 192 86.13 192 192C448 297.4 434.7 335.7 412.3 367.1z"></path></svg>'
@@ -272,21 +274,36 @@ class Display {
                         status = '';
                 }
 
-                link = status + `<a class="attendee_link" href='mailto:` + attendee["email"] + `' aria-haspopup="false" onClick="` + attendee["onclick"]
-                    + `">` + display + `</a><br>`;
+                let $link = $('<a>', {
+                    class: 'attendee_link',
+                    href: 'mailto:' + attendee['email'],
+                    'aria-haspopup': 'false',
+                    text: display
+                });
+                $link.on('click', function () {
+                    return rcmail.command('compose', attendee['email'], this);
+                });
+
+                let $line = $('<span>').text(status).append($link).append($('<br>'));
 
                 if (attendee['partstat'] === 'ORGANIZER') {
-                    this.event_template_html.find('.attendee').prepend(link);
+                    this.event_template_html.find('.attendee').prepend($line);
                 } else {
-                    this.event_template_html.find('.attendee').append(link);
+                    this.event_template_html.find('.attendee').append($line);
                 }
 
             }
 
-            let attribut = this.array_response['attr_reply_all'];
-            let link = `<a href='reply_all' aria-haspopup="false" onClick="` + attribut["onclick"] + `">`
-                + rcmail.gettext('reply_all', 'roundcube_caldav') + `</a><br>`;
-            this.event_template_html.find('.reply_all').append(link);
+            let reply_all = this.array_response['attr_reply_all'];
+            let $replyLink = $('<a>', {
+                href: 'reply_all',
+                'aria-haspopup': 'false',
+                text: rcmail.gettext('reply_all', 'roundcube_caldav')
+            });
+            $replyLink.on('click', function () {
+                return rcmail.command('compose', reply_all['emails'], this);
+            });
+            this.event_template_html.find('.reply_all').append($replyLink).append($('<br>'));
         } else {
             this.event_template_html.find('.attendees').hide();
         }
@@ -309,16 +326,12 @@ class Display {
                     summary = rcmail.gettext('missing_summary', 'roundcube_caldav');
                 }
                 
-                this.event_template_html.find('.previous').append(
-                    summary 
-                    + ': ' 
-                    + '<i>' 
-                    + '('
-                    + prev['calendar'] 
-                    + ')' 
-                    + '</i><br>'
-                    + prev['pretty_date']
-                );
+                let $entry = $('<div>');
+                $entry.append(document.createTextNode(summary + ': '));
+                $entry.append($('<i>').text('(' + prev['calendar'] + ')'));
+                $entry.append($('<br>'));
+                $entry.append(document.createTextNode(prev['pretty_date']));
+                this.event_template_html.find('.previous').append($entry);
             } else {
                 this.event_template_html.find('.previous').hide();
             }
@@ -330,16 +343,12 @@ class Display {
                     summary = rcmail.gettext('missing_summary', 'roundcube_caldav');
                 }
                 
-                this.event_template_html.find('.next').append(
-                    summary 
-                    + ': ' 
-                    + '<i>' 
-                    + '('
-                    + next['calendar'] 
-                    + ')' 
-                    + '</i><br>' 
-                    + next['pretty_date']
-                );
+                let $entry = $('<div>');
+                $entry.append(document.createTextNode(summary + ': '));
+                $entry.append($('<i>').text('(' + next['calendar'] + ')'));
+                $entry.append($('<br>'));
+                $entry.append(document.createTextNode(next['pretty_date']));
+                this.event_template_html.find('.next').append($entry);
             } else {
                 this.event_template_html.find('.next').hide();
             }
@@ -360,16 +369,12 @@ class Display {
                             summary = rcmail.gettext('missing_summary', 'roundcube_caldav');
                         }
                         
-                        this.event_template_html.find('.meeting_collision').append(
-                            summary 
-                            + ':  ' 
-                            + display_date 
-                            + ' <i>' 
-                            + '('
-                            + calendar_name 
-                            + ')' 
-                            + '</i><br>'
-                        );
+                        let $entry = $('<div>');
+                        $entry.append(document.createTextNode(summary + ':  '));
+                        $entry.append(document.createTextNode(display_date + ' '));
+                        $entry.append($('<i>').text('(' + calendar_name + ')'));
+                        $entry.append($('<br>'));
+                        this.event_template_html.find('.meeting_collision').append($entry);
                     }
                 }
 
@@ -404,10 +409,11 @@ class Display {
             }
             
             for (let [calendar_id, calendar_name] of Object.entries(this.array_response['used_calendar'])) {
-                let selected = calendar_name === this.array_response['main_calendar_name'] ? 'selected' : '';
-                select.append(
-                    `<option value="` + calendar_id + `"` + selected + '>' + calendar_name + '</option>'
-                );
+                let $option = $('<option>').val(calendar_id).text(calendar_name);
+                if (calendar_name === this.array_response['main_calendar_name']) {
+                    $option.prop('selected', true);
+                }
+                select.append($option);
             }
         } else {
             $calendar_choice.hide();
@@ -463,41 +469,41 @@ class Display {
         // On affiche des titres différents selon le role ou la methode
         if (isOrganizer && isACounter) {
             if (modif || !this.array_response['found_older_event_on_calendar']) {
-                $invitation.append('<h3>' + rcmail.gettext('invitation_modification', 'roundcube_caldav') + '</h3>');
+                $invitation.append($('<h3>').text(rcmail.gettext('invitation_modification', 'roundcube_caldav')));
             } else {
-                $invitation.append('<h3>' + rcmail.gettext('invitation_modification_already_studied', 'roundcube_caldav') + '</h3>');
+                $invitation.append($('<h3>').text(rcmail.gettext('invitation_modification_already_studied', 'roundcube_caldav')));
             }
         } else if (isOrganizer && isAReply) {
             if (sender) {
                 if (this.array_response['sender_partstat'] === 'ACCEPTED') {
-                    $invitation.append('<h3>' + sender_name + rcmail.gettext('invitation_accepted', 'roundcube_caldav') + '</h3>');
+                    $invitation.append($('<h3>').text(sender_name + rcmail.gettext('invitation_accepted', 'roundcube_caldav')));
                 } else if (this.array_response['sender_partstat'] === 'TENTATIVE') {
-                    $invitation.append('<h3>' + sender_name + rcmail.gettext('invitation_tentative', 'roundcube_caldav') + '</h3>');
+                    $invitation.append($('<h3>').text(sender_name + rcmail.gettext('invitation_tentative', 'roundcube_caldav')));
                 } else {
-                    $invitation.append('<h3>' + sender_name + rcmail.gettext('invitation_declined', 'roundcube_caldav') + '</h3>');
+                    $invitation.append($('<h3>').text(sender_name + rcmail.gettext('invitation_declined', 'roundcube_caldav')));
                 }
             } else {
-                $invitation.append('<h3>' + this.array_response['sender_email'] + rcmail.gettext('unknown_reply', 'roundcube_caldav') + '</h3>');
+                $invitation.append($('<h3>').text(this.array_response['sender_email'] + rcmail.gettext('unknown_reply', 'roundcube_caldav')));
             }
 
         } else if (isOrganizer && isARequest) {
-            $invitation.append('<h3>' + rcmail.gettext('invitation_send', 'roundcube_caldav') + '</h3>');
+            $invitation.append($('<h3>').text(rcmail.gettext('invitation_send', 'roundcube_caldav')));
         } else if (isOrganizer && isADeclineCounter) {
-            $invitation.append('<h3>' + rcmail.gettext('invitation_decline_modifications1', 'roundcube_caldav') + receiver_name
-                + rcmail.gettext('invitation_decline_modifications2', 'roundcube_caldav') + '</h3>');
+            $invitation.append($('<h3>').text(rcmail.gettext('invitation_decline_modifications1', 'roundcube_caldav') + receiver_name
+                + rcmail.gettext('invitation_decline_modifications2', 'roundcube_caldav')));
         } else if (isOrganizer && isACancel) {
-            $invitation.append('<h3>' + rcmail.gettext('<h3>' + rcmail.gettext('invitation_cancel_for_organizer', 'roundcube_caldav') + '</h3>'));
+            $invitation.append($('<h3>').text(rcmail.gettext('invitation_cancel_for_organizer', 'roundcube_caldav')));
         } else if (!isOrganizer && isACancel) {
-            $invitation.append('<h3>' + rcmail.gettext('invitation_cancel', 'roundcube_caldav') + '</h3>');
+            $invitation.append($('<h3>').text(rcmail.gettext('invitation_cancel', 'roundcube_caldav')));
         } else if (!isOrganizer && isADeclineCounter) {
-            $invitation.append('<h3>' + rcmail.gettext('invitation_declined_by_organizer', 'roundcube_caldav') + '</h3>');
+            $invitation.append($('<h3>').text(rcmail.gettext('invitation_declined_by_organizer', 'roundcube_caldav')));
         } else {
-            $invitation.append('<h3>' + rcmail.gettext('invitation', 'roundcube_caldav') + '</h3>');
+            $invitation.append($('<h3>').text(rcmail.gettext('invitation', 'roundcube_caldav')));
         }
         if (used_event['summary']) {
-            $invitation.append('<h4>' + used_event['summary'] + '</h4>');
+            $invitation.append($('<h4>').text(used_event['summary']));
         } else {
-            $invitation.append('<h4>' + rcmail.gettext('no_title', 'roundcube_caldav') + '</h4>');
+            $invitation.append($('<h4>').text(rcmail.gettext('no_title', 'roundcube_caldav')));
         }
     }
 
@@ -511,19 +517,19 @@ class Display {
         
         if (recurrent_event.length > 1) {
             if (this.array_response['rrule_to_text']) {
-                this.event_template_html.find('.repeated').append(this.array_response['rrule_to_text'] + '<br>-<br>');
+                this.event_template_html.find('.repeated').append($('<span>').text(this.array_response['rrule_to_text'])).append($('<br>')).append(document.createTextNode('-')).append($('<br>'));
             }
             
             // on affiche seulement les dix premier evt si il yen a plus
             for (let i = 0; i < 10; i++) {
                 if (recurrent_event[i]) {
-                    this.event_template_html.find('.repeated').append(recurrent_event[i] + '<br>');
+                    this.event_template_html.find('.repeated').append($('<span>').text(recurrent_event[i])).append($('<br>'));
                 } else {
                     break;
                 }
 
                 if (i === 9) {
-                    this.event_template_html.find('.repeated').append('...');
+                    this.event_template_html.find('.repeated').append(document.createTextNode('...'));
                 }
             }
         } else {

--- a/lib/php/set_response.php
+++ b/lib/php/set_response.php
@@ -27,11 +27,10 @@ use ICal\ICal;
  * bool:RSVP,
  * partstat: Participation status,
  * ROLE: attendee/organizer,
- * email,
- * onclick: action to add for the participant button]
+ * email]
  *
  * And Fill the action to add on reply_all button
- * $response['attr_reply_all'] = [onclick]
+ * $response['attr_reply_all'] = [emails]
  * @param Event $event
  * @param array $response
  */
@@ -62,7 +61,6 @@ function set_participants_characteristics_and_set_buttons_properties(Event $even
                 $response['attendees'][$id]['ROLE'] = array_key_exists('ROLE', $attendee) ? $attendee['ROLE']: null;
             } elseif (is_string($attendee) && str_start_with($attendee, 'mailto:')) {
                 $response['attendees'][$id]['email'] = substr($attendee, strlen('mailto:'));
-                $response['attendees'][$id]['onclick'] = "return " . rcmail_output::JS_OBJECT_NAME . ".command('compose','" . $response['attendees'][$id]['email'] . "',this)";
                 if ($my_email !== $response['attendees'][$id]['email']) {
                     $all_adresses .= $response['attendees'][$id]['email'] . ';';
                 }
@@ -80,7 +78,6 @@ function set_participants_characteristics_and_set_buttons_properties(Event $even
                 $organizer_email = substr($organizer, strlen('mailto:'));
                 $organizer_array['email'] = $organizer_email;
                 $organizer_array['partstat'] = 'ORGANIZER';
-                $organizer_array['onclick'] = "return " . rcmail_output::JS_OBJECT_NAME . ".command('compose','" . $organizer_email . "',this)";
                 
                 if ($my_email !== $organizer_email) {
                     $all_adresses .= $organizer_email . ';';
@@ -97,7 +94,7 @@ function set_participants_characteristics_and_set_buttons_properties(Event $even
     $all_adresses = substr($all_adresses, 0, -1);
     
     $response['attr_reply_all'] = [
-        'onclick' => "return " . rcmail_output::JS_OBJECT_NAME . ".command('compose','" . $all_adresses . "',this)"
+        'emails' => $all_adresses
     ];
 }
 
@@ -270,7 +267,7 @@ function set_if_modification_date_location_description_attendees(array &$respons
     }
     
     if (!empty($event->description) && $event_to_compare_with->description === $event->description) {
-        $response['new_description'] = nl2br($event->description);
+        $response['new_description'] = $event->description;
     }
     
     if (

--- a/roundcube_caldav.php
+++ b/roundcube_caldav.php
@@ -681,7 +681,7 @@ class roundcube_caldav extends rcube_plugin
             set_method_field($ical, $response, $is_Organizer);
 
             if (isset($event->comment) && $event->comment) {
-                $response['comment'] = nl2br($event->comment);
+                $response['comment'] = $event->comment;
             }
 
             set_if_an_older_event_was_found_on_server(
@@ -760,7 +760,7 @@ class roundcube_caldav extends rcube_plugin
             }
 
             if (!empty($event->description)) {
-                $response['description'] = nl2br($event->description);
+                $response['description'] = $event->description;
             } else {
                 $response['description']='';
             }

--- a/skins/roundcube_caldav.css
+++ b/skins/roundcube_caldav.css
@@ -270,6 +270,10 @@ fieldset {
     text-align: center;
 }
 
-.attendee_link  {
+.description, .location, .comment, .if_new_description, .if_new_location {
+    white-space: pre-wrap;
+}
+
+.attendee_link {
     margin-left: 0.5em;
 }


### PR DESCRIPTION
Render event data with safe DOM APIs instead of inline onclick handlers and unescaped HTML insertion.